### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/NatureBookWebsite/efb171d0-1c67-4778-8347-fa4beb9a7d02/2562574e-9b7c-4922-a5b7-a5ec2773e34f/_apis/work/boardbadge/95cbc268-308d-4c73-94f9-f2121481711d)](https://dev.azure.com/NatureBookWebsite/efb171d0-1c67-4778-8347-fa4beb9a7d02/_boards/board/t/2562574e-9b7c-4922-a5b7-a5ec2773e34f/Microsoft.RequirementCategory)
 # Nature Book Website
  "The book of nature" DK conversion to an interactive website project to learn new skills in various areas. 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/NatureBookWebsite/efb171d0-1c67-4778-8347-fa4beb9a7d02/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.